### PR TITLE
KDS-54 이미지경로 반환 기능 추가

### DIFF
--- a/spy.log
+++ b/spy.log
@@ -1,0 +1,42 @@
+1652696939079|10|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists diary CASCADE |     drop table if exists diary CASCADE 
+1652696939088|6|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists diary_image CASCADE |     drop table if exists diary_image CASCADE 
+1652696939090|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists koons_comment CASCADE |     drop table if exists koons_comment CASCADE 
+1652696939091|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists question CASCADE |     drop table if exists question CASCADE 
+1652696939091|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists question_answer CASCADE |     drop table if exists question_answer CASCADE 
+1652696939098|6|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists refresh_token CASCADE |     drop table if exists refresh_token CASCADE 
+1652696939101|2|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists share_group CASCADE |     drop table if exists share_group CASCADE 
+1652696939101|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists share_group_diary CASCADE |     drop table if exists share_group_diary CASCADE 
+1652696939105|3|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists share_group_diary_comment CASCADE |     drop table if exists share_group_diary_comment CASCADE 
+1652696939106|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists share_group_diary_image CASCADE |     drop table if exists share_group_diary_image CASCADE 
+1652696939107|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists share_group_invite CASCADE |     drop table if exists share_group_invite CASCADE 
+1652696939108|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists share_group_member CASCADE |     drop table if exists share_group_member CASCADE 
+1652696939109|1|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop table if exists user CASCADE |     drop table if exists user CASCADE 
+1652696939110|0|statement|connection 33|url jdbc:h2:mem:61b30222-a72e-4935-9308-5fee6d229a69|     drop sequence if exists hibernate_sequence|     drop sequence if exists hibernate_sequence
+1652696939142|1|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists diary CASCADE |     drop table if exists diary CASCADE 
+1652696939144|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists diary_image CASCADE |     drop table if exists diary_image CASCADE 
+1652696939144|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists koons_comment CASCADE |     drop table if exists koons_comment CASCADE 
+1652696939144|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists question CASCADE |     drop table if exists question CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists question_answer CASCADE |     drop table if exists question_answer CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists refresh_token CASCADE |     drop table if exists refresh_token CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists share_group CASCADE |     drop table if exists share_group CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists share_group_diary CASCADE |     drop table if exists share_group_diary CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists share_group_diary_comment CASCADE |     drop table if exists share_group_diary_comment CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists share_group_diary_image CASCADE |     drop table if exists share_group_diary_image CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists share_group_invite CASCADE |     drop table if exists share_group_invite CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists share_group_member CASCADE |     drop table if exists share_group_member CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop table if exists user CASCADE |     drop table if exists user CASCADE 
+1652696939145|0|statement|connection 34|url jdbc:h2:mem:test|     drop sequence if exists hibernate_sequence|     drop sequence if exists hibernate_sequence
+1652697135551|14|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists diary CASCADE |     drop table if exists diary CASCADE 
+1652697135562|5|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists diary_image CASCADE |     drop table if exists diary_image CASCADE 
+1652697135564|1|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists koons_comment CASCADE |     drop table if exists koons_comment CASCADE 
+1652697135565|1|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists question CASCADE |     drop table if exists question CASCADE 
+1652697135567|1|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists question_answer CASCADE |     drop table if exists question_answer CASCADE 
+1652697135567|0|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists refresh_token CASCADE |     drop table if exists refresh_token CASCADE 
+1652697135569|1|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists share_group CASCADE |     drop table if exists share_group CASCADE 
+1652697135570|0|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists share_group_diary CASCADE |     drop table if exists share_group_diary CASCADE 
+1652697135571|0|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists share_group_diary_comment CASCADE |     drop table if exists share_group_diary_comment CASCADE 
+1652697135571|0|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists share_group_diary_image CASCADE |     drop table if exists share_group_diary_image CASCADE 
+1652697135572|0|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists share_group_invite CASCADE |     drop table if exists share_group_invite CASCADE 
+1652697135573|0|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists share_group_member CASCADE |     drop table if exists share_group_member CASCADE 
+1652697135575|1|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop table if exists user CASCADE |     drop table if exists user CASCADE 
+1652697135578|2|statement|connection 34|url jdbc:h2:mem:f92ff851-98a7-481f-94a1-9375ece22807|     drop sequence if exists hibernate_sequence|     drop sequence if exists hibernate_sequence

--- a/src/main/java/UPF2022SS/KoonsDiarySpring/api/controller/DiaryApiController.java
+++ b/src/main/java/UPF2022SS/KoonsDiarySpring/api/controller/DiaryApiController.java
@@ -11,9 +11,6 @@ import UPF2022SS.KoonsDiarySpring.service.diary.sub.S3Service;
 import UPF2022SS.KoonsDiarySpring.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -131,24 +128,6 @@ public class DiaryApiController {
         return response;
     }
 
-    @GetMapping(value = "/diary/{imagePath}")
-    public ResponseEntity<ByteArrayResource> getDiaryImage(
-            @RequestHeader("Authorization") final String header, @PathVariable("imagePath") String imagePath
-    ){
-        try{
-            if(header == null){
-                return ResponseEntity
-                        .badRequest()
-                        .build();
-            }
-            return diaryService.getDiaryImage(imagePath);
-        }catch (Exception e){
-            return ResponseEntity
-                    .badRequest()
-                    .build();
-        }
-    }
-
     /*
      * 다이어리 업데이트 반환하는 API
      */
@@ -175,8 +154,6 @@ public class DiaryApiController {
                     fileUrls.add(fileUrl);
                 }
 
-//                Long id = jwtService.decodeAccessToken(header);
-
                 DefaultResponse response = diaryService.patchDiary(request, fileUrls);
                 return response;
             } catch (Exception e) {
@@ -187,7 +164,6 @@ public class DiaryApiController {
                         e.getMessage());
             }
     }
-
 
 
 

--- a/src/main/java/UPF2022SS/KoonsDiarySpring/service/diary/DiaryService.java
+++ b/src/main/java/UPF2022SS/KoonsDiarySpring/service/diary/DiaryService.java
@@ -3,15 +3,11 @@ package UPF2022SS.KoonsDiarySpring.service.diary;
 
 import UPF2022SS.KoonsDiarySpring.api.dto.diary.*;
 import UPF2022SS.KoonsDiarySpring.api.dto.DefaultResponse;
-import UPF2022SS.KoonsDiarySpring.domain.Diary;
-import UPF2022SS.KoonsDiarySpring.domain.DiaryImage;
 import UPF2022SS.KoonsDiarySpring.domain.User;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import javax.sound.midi.Patch;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -32,7 +28,7 @@ public interface DiaryService {
 
     public DefaultResponse getDiaryListByLocalDate(User user, LocalDate startDate, LocalDate endDate);
 
-    public ResponseEntity<ByteArrayResource> getDiaryImage(String imagePath);
+    public ResponseEntity<ByteArrayResource> getDiaryImageV1(String imagePath);
     // 감정 분석 api 서비스
 
     // 감정 선택 서비스

--- a/src/main/java/UPF2022SS/KoonsDiarySpring/service/diary/DiaryServiceImpl.java
+++ b/src/main/java/UPF2022SS/KoonsDiarySpring/service/diary/DiaryServiceImpl.java
@@ -157,13 +157,6 @@ public class DiaryServiceImpl implements DiaryService{
     @Override
     public DefaultResponse getDiaryList(User user) {
 
-//        Optional<User> findUser = userJpaRepository.findById(userId);
-//        if(User == null){
-//            return DefaultResponse.response(
-//                    StatusCode.BAD_REQUEST,
-//                    ResponseMessage.USER_SEARCH_FAIL
-//            );
-//        }
         List<Diary> diaryList = diaryJpaRepository.findAllById(user.getId());
 
         ObjectMapper mapper = new ObjectMapper();
@@ -363,7 +356,7 @@ public class DiaryServiceImpl implements DiaryService{
     }
 
     @Override
-    public ResponseEntity<ByteArrayResource> getDiaryImage(String imagePath) {
+    public ResponseEntity<ByteArrayResource> getDiaryImageV1(String imagePath) {
         byte[] data = s3Service.downloadFile(imagePath);
         ByteArrayResource resource = new ByteArrayResource(data);
         HttpHeaders headers = buildHeaders(imagePath, data);
@@ -381,6 +374,8 @@ public class DiaryServiceImpl implements DiaryService{
         headers.setContentDisposition(CommonUtils.createContentDisposition(resourcePath));
         return headers;
     }
+
+
 
     private Boolean validateCheckDiary(Diary diary){
         return null;

--- a/src/test/java/UPF2022SS/KoonsDiarySpring/service/diary/GetDiaryImageTest.java
+++ b/src/test/java/UPF2022SS/KoonsDiarySpring/service/diary/GetDiaryImageTest.java
@@ -8,8 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 class GetDiaryImageTest {
@@ -19,7 +17,7 @@ class GetDiaryImageTest {
 
     @Test
     void getDiaryImage() {
-        ResponseEntity rs = diaryService.getDiaryImage("1KakaoTalk_Photo_2022-05-15-01-06-491652632952961.jpeg");
+        ResponseEntity rs = diaryService.getDiaryImageV1("1KakaoTalk_Photo_2022-05-15-01-06-491652632952961.jpeg");
         Assertions.assertThat(rs).isNotNull();
         System.out.println("rs = " + rs);
     }


### PR DESCRIPTION
# 기존 이미지 자체 반환기능을 제거했습니다.
---


외부 라이브러리(aws.s3)를 끌어다 사용하다보니 예외또한 별도의 라이브러리에서 끌어다가 지정해줘야 하는 상황이었고
이미지가 존재하지 않을 경우 status가 아닌 라이브러리 객체에서 에러를 뿌리다 보니 테스트 환경 구성도 다소 어려웠습니다.

경로반환기능은 기존의 getDiary를 수행할 경우 comment와 함께 리스트 타입으로 반환이 됩니다. 
프론트쪽에서 두개의 리스트를 같이 iterate하면서 
사용하시면 될 것 같습니다.